### PR TITLE
Starter develop bool

### DIFF
--- a/src/behaviors/bhv_starter_clearball.py
+++ b/src/behaviors/bhv_starter_clearball.py
@@ -12,7 +12,7 @@ class BhvStarterClearBall():
         pass
     
 
-    def execute(agent: IAgent):
+    def execute(self, agent: IAgent):
         wm = agent.wm
         ball_pos = Vector2D(wm.ball.position.x, wm.ball.position.y)
         target = Vector2D(agent.server_params.pitch_half_length, 0.0)

--- a/src/behaviors/bhv_starter_dribble.py
+++ b/src/behaviors/bhv_starter_dribble.py
@@ -11,7 +11,7 @@ class BhvStarterDribble():
     def __init__(self):
         pass
 
-    def execute(agent: IAgent):
+    def execute(self, agent: IAgent):
         wm = agent.wm
         ball_pos = Vector2D(wm.ball.position.x, wm.ball.position.y)
         dribble_angle = (Vector2D(52.5, 0) - ball_pos).th().degree()

--- a/src/behaviors/bhv_starter_kick_planner.py
+++ b/src/behaviors/bhv_starter_kick_planner.py
@@ -11,29 +11,29 @@ from src.utils.tools import Tools
 
 class BhvStarterKickPlanner(IBehavior):
     def __init__(self):
-        '''self.starter_shoot = BhvStarterShoot()
+        self.starter_shoot = BhvStarterShoot()
         self.starter_clear_ball = BhvStarterClearBall()
         self.starter_dribble = BhvStarterDribble()
-        self.starter_pass = BhvStarterPass()'''
+        self.starter_pass = BhvStarterPass()
 
     def execute(self, agent: IAgent):
         agent.logger.debug("BhvStarterKickPlanner.execute")
         from src.sample_player_agent import SamplePlayerAgent  # Local import to avoid circular import
         actions = []
-        actions += [shoot] if (shoot := BhvStarterShoot.execute(agent)) is not None else []
+        actions += [shoot] if (shoot := self.starter_shoot.execute(agent)) is not None else []
         opps = Tools.OpponentsFromSelf(agent)
         nearest_opp = opps[0] if opps else None
         nearest_opp_dist = nearest_opp.dist_from_self if nearest_opp else 1000.0
         
         if nearest_opp_dist < 10:
-            actions += [passing] if (passing := BhvStarterPass.execute(agent)) is not None else []
+            actions += [passing] if (passing := self.starter_pass.execute(agent)) is not None else []
             
-        actions += [dribble] if (dribble := BhvStarterDribble.execute(agent)) is not None else []
+        actions += [dribble] if (dribble := self.starter_dribble.execute(agent)) is not None else []
         
         if nearest_opp_dist > 2.5:
             actions.append(PlayerAction(body_hold_ball=Body_HoldBall()))
 
-        actions.append(BhvStarterClearBall.execute(agent))
+        actions.append(self.starter_clear_ball.execute(agent))
         
         #Sending actions' queue
         for i in actions:

--- a/src/behaviors/bhv_starter_pass.py
+++ b/src/behaviors/bhv_starter_pass.py
@@ -11,7 +11,7 @@ class BhvStarterPass():
     def __init__(self):
         pass
 
-    def execute(agent: IAgent) -> PlayerAction:
+    def execute(self, agent: IAgent) -> PlayerAction:
         
         wm = agent.wm
         target = []
@@ -39,5 +39,5 @@ class BhvStarterPass():
             else :
                 return PlayerAction(body_smart_kick=Body_SmartKick(target_point=best_target.position, first_speed=2.5, first_speed_threshold=2.5, max_steps=1))
         
-        return 
+        return
                 

--- a/src/behaviors/bhv_starter_penalty.py
+++ b/src/behaviors/bhv_starter_penalty.py
@@ -92,7 +92,8 @@ class BhvStarterPenalty(IBehavior):
         goal_c = Vector2D(agent.server_params.pitch_half_length,0)
         opp_goalie = Tools.OpponentGoalie(agent)
         place_angle = 0.0
-        go_to_placed_ball = BhvStarterGoToPlacedBall(place_angle).execute(agent)
+        go_to_placed_ball = BhvStarterGoToPlacedBall(place_angle)
+        go_to_placed_ball = go_to_placed_ball.execute(agent)
         if go_to_placed_ball == []:
             actions.append(PlayerAction(body_turn_to_point=Body_TurnToPoint(target_point=Convertor.convert_vector2d_to_rpc_vector2d(goal_c), cycle=2)))
         else:
@@ -324,7 +325,8 @@ class BhvStarterPenalty(IBehavior):
                 actions.append(PlayerAction(body_turn_to_point=Body_TurnToPoint(target_point=Convertor.convert_vector2d_to_rpc_vector2d(drib_target), cycle=2)))
 
         else:
-            actions.append(BhvStarterDribble.execute(agent))
+            dribble = BhvStarterDribble()
+            actions.append(dribble.execute(agent))
 
         return actions
 
@@ -352,7 +354,8 @@ class BhvStarterPenalty(IBehavior):
             actions.append(PlayerAction(catch=Catch()))
 
         if wm.self.is_kickable:
-            actions.append(BhvStarterClearBall.execute(agent))
+            clear_ball = BhvStarterClearBall()
+            actions.append(clear_ball.execute(agent))
 
         if not SP.pen_allow_mult_kicks:
             if pow(Convertor.convert_rpc_vector2d_to_vector2d(wm.ball.velocity).r(), 2) < 0.01 and abs(wm.ball.position.x) < SP.pitch_half_length - SP.pen_dist_x - 1.0:

--- a/src/behaviors/bhv_starter_penalty.py
+++ b/src/behaviors/bhv_starter_penalty.py
@@ -149,7 +149,7 @@ class BhvStarterPenalty(IBehavior):
             if opp_goalie:
                 actions.append(PlayerAction(neck_turn_to_point=Neck_TurnToPoint(target_point=opp_goalie.position)))
             else:
-                goal_c = RpcVector2D(agent.server_params.pitch_half_length,0)
+                goal_c = RpcVector2D(x=agent.server_params.pitch_half_length, y=0)
                 actions.append(PlayerAction(neck_turn_to_point=Neck_TurnToPoint(target_point=goal_c)))
             return []
 
@@ -338,7 +338,7 @@ class BhvStarterPenalty(IBehavior):
         actions.append(PlayerAction(body_go_to_point=Body_GoToPoint(target_point=Convertor.convert_vector2d_to_rpc_vector2d(move_point), distance_threshold=0.5, max_dash_power=agent.server_params.max_dash_power)))
 
         if abs(agent.wm.self.body_direction) > 2.0:
-            actions.append(PlayerAction(body_turn_to_point=Body_TurnToPoint(target_point=RpcVector2D(0, 0), cycle=2)))
+            actions.append(PlayerAction(body_turn_to_point=Body_TurnToPoint(target_point=RpcVector2D(x=0, y=0), cycle=2)))
         return actions
 
     def do_goalie(self, agent: IAgent):

--- a/src/behaviors/bhv_starter_shoot.py
+++ b/src/behaviors/bhv_starter_shoot.py
@@ -9,7 +9,7 @@ class BhvStarterShoot():
     def __init__(self):
         pass
     
-    def execute(agent: IAgent):
+    def execute(self, agent: IAgent):
         wm = agent.wm
         ball_pos = Vector2D(wm.ball.position.x, wm.ball.position.y)
         ball_max_velocity = agent.server_params.ball_speed_max

--- a/src/behaviors/starter_setplay/bhv_starter_go_to_placed_ball.py
+++ b/src/behaviors/starter_setplay/bhv_starter_go_to_placed_ball.py
@@ -8,11 +8,12 @@ class BhvStarterGoToPlacedBall:
     
     def __init__(self, angle: float):
         self.M_ball_place_angle = angle  
-        pass
+        
 
     def execute(self, agent: IAgent):
         actions = []
         from src.behaviors.starter_setplay.bhv_starter_setplay import BhvStarterSetPlay
+        setplay = BhvStarterSetPlay()
         
         dir_margin = 15.0
         sp = agent.server_params
@@ -31,7 +32,7 @@ class BhvStarterGoToPlacedBall:
         dash_power = 20.0
         dash_speed = -1.0
         if wm.ball.dist_from_self > 2.0:
-            dash_power = BhvStarterSetPlay.get_set_play_dash_power(agent)
+            dash_power = setplay.get_set_play_dash_power(agent)
         else:
             dash_speed = agent.player_types[wm.self.id].player_size
             dash_power = Tools.GetDashPowerToKeepSpeed(agent, dash_speed, wm.self.effort) #DEBUG NEEDED

--- a/src/behaviors/starter_setplay/bhv_starter_prepare_setplay_kick.py
+++ b/src/behaviors/starter_setplay/bhv_starter_prepare_setplay_kick.py
@@ -9,10 +9,12 @@ class BhvStarterPrepareSetPlayKick:
         self.M_wait_cycle = wait_cycle
 
     def execute(self, agent: IAgent) -> bool:
-        actions = []
         from src.behaviors.starter_setplay.bhv_starter_go_to_placed_ball import BhvStarterGoToPlacedBall
+        go_to_placed_ball = BhvStarterGoToPlacedBall(self.M_ball_place_angle)
+        
+        actions = []
         # Not reach the ball side
-        actions += BhvStarterGoToPlacedBall(self.M_ball_place_angle).execute(agent)
+        actions += go_to_placed_ball.execute(agent)
 
         # Reach to ball side
         if self.s_rest_wait_cycle < 0:

--- a/src/behaviors/starter_setplay/bhv_starter_setplay_freekick.py
+++ b/src/behaviors/starter_setplay/bhv_starter_setplay_freekick.py
@@ -20,19 +20,22 @@ class BhvStarterSetPlayFreeKick:
     def __init__(self):
         pass
     
-    def execute(agent: IAgent):
+    def execute(self, agent: IAgent):
         from src.behaviors.starter_setplay.bhv_starter_setplay import BhvStarterSetPlay
-        if BhvStarterSetPlay.is_kicker(agent):
-            return BhvStarterSetPlayFreeKick.doKick(agent)
+        selfplay = BhvStarterSetPlay()
+        if selfplay.is_kicker(agent):
+            return self.doKick(agent)
         else:
-            return BhvStarterSetPlayFreeKick.do_move(agent)
+            return self.do_move(agent)
 
-    def doKick(agent:IAgent):
-        actions = []
+    def doKick(self, agent:IAgent):
         from src.behaviors.starter_setplay.bhv_starter_go_to_placed_ball import BhvStarterGoToPlacedBall
+        go_to_placed_ball = BhvStarterGoToPlacedBall(0.0)
+        actions = []
+        
         # go to the ball position
-        actions += BhvStarterGoToPlacedBall(0.0).execute(agent)
-        wait = BhvStarterSetPlayFreeKick.doKickWait(agent)
+        actions += go_to_placed_ball.execute(agent)
+        wait = self.doKickWait(agent)
         if wait != []:
             actions += wait
             return actions
@@ -41,7 +44,8 @@ class BhvStarterSetPlayFreeKick:
         max_ball_speed = wm.self.kick_rate * agent.server_params.max_power
 
         # pass
-        actions.append(BhvStarterPass.execute(agent))
+        passer = BhvStarterPass()
+        actions.append(passer.execute(agent))
 
         # kick to the nearest teammate
 
@@ -69,14 +73,15 @@ class BhvStarterSetPlayFreeKick:
         if abs(wm.ball.angle_from_self - wm.self.body_direction) > 1.5:
             actions.append(PlayerAction(body_turn_to_ball=Body_TurnToBall(cycle=1)))
             return actions
-
-        actions.append(BhvStarterClearBall.execute(agent))
+        clear_ball = BhvStarterClearBall()
+        actions.append(clear_ball.execute(agent))
         return actions
 
 
-    def doKickWait(agent:IAgent):
-        wm = agent.wm
+    def doKickWait(self, agent:IAgent):
         from src.behaviors.starter_setplay.bhv_starter_setplay import BhvStarterSetPlay
+        selfplay = BhvStarterSetPlay()
+        wm = agent.wm
         actions = []
         real_set_play_count = wm.cycle - wm.last_set_play_start_time
 
@@ -91,7 +96,7 @@ class BhvStarterSetPlayFreeKick:
             actions.append(PlayerAction(body_turn_to_point=Body_TurnToPoint(target_point=Convertor.convert_vector2d_to_rpc_vector2d(face_point))))
             return actions
 
-        if BhvStarterSetPlay.is_delaying_tactics_situation(agent):
+        if selfplay.is_delaying_tactics_situation(agent):
             actions.append(PlayerAction(body_turn_to_point=Body_TurnToPoint(target_point=Convertor.convert_vector2d_to_rpc_vector2d(face_point))))
             return actions
 
@@ -118,7 +123,7 @@ class BhvStarterSetPlayFreeKick:
 
         return []
 
-    def do_move(agent: "SamplePlayerAgent"):
+    def do_move(self, agent: "SamplePlayerAgent"):
         wm = agent.wm
         actions = []
         target_point_rpc = Convertor.convert_vector2d_to_rpc_vector2d(agent.strategy.get_position(wm.self.uniform_number, agent))
@@ -145,7 +150,8 @@ class BhvStarterSetPlayFreeKick:
 
         target_point.set_x(min(target_point.x(), wm.offside_line_x - 0.5))
         from src.behaviors.starter_setplay.bhv_starter_setplay import BhvStarterSetPlay
-        dash_power = BhvStarterSetPlay.get_set_play_dash_power(agent)
+        selfplay = BhvStarterSetPlay()
+        dash_power = selfplay.get_set_play_dash_power(agent)
         dist_thr = wm.ball.dist_from_self * 0.07
         if dist_thr < 1.0:
             dist_thr = 1.0

--- a/src/behaviors/starter_setplay/bhv_starter_setplay_goal_kick.py
+++ b/src/behaviors/starter_setplay/bhv_starter_setplay_goal_kick.py
@@ -67,7 +67,7 @@ class BhvStarterSetPlayGoalKick:
         
         actions.append(PlayerAction(body_go_to_point=Body_GoToPoint(target_point=Convertor.convert_vector2d_to_rpc_vector2d(ball_final), distance_threshold=2.0, max_dash_power=agent.server_params.max_dash_power)))
         
-        actions.append(PlayerAction(body_turn_to_point=Body_TurnToPoint(target_point=RpcVector2D(0, 0), cycle=2)))
+        actions.append(PlayerAction(body_turn_to_point=Body_TurnToPoint(target_point=RpcVector2D(x=0, y=0), cycle=2)))
         
         return actions
 

--- a/src/behaviors/starter_setplay/bhv_starter_setplay_goal_kick.py
+++ b/src/behaviors/starter_setplay/bhv_starter_setplay_goal_kick.py
@@ -14,42 +14,44 @@ from src.utils.convertor import Convertor
 if TYPE_CHECKING:
     from src.sample_player_agent import SamplePlayerAgent
 class BhvStarterSetPlayGoalKick:
-    def __init__():
+    def __init__(self):
         pass
     
-    def execute(agent:IAgent):
+    def execute(self, agent:IAgent):
         from src.behaviors.starter_setplay.bhv_starter_setplay import BhvStarterSetPlay
-        if BhvStarterSetPlay.is_kicker(agent):
-            return BhvStarterSetPlayGoalKick.do_kick(agent)
+        setplay = BhvStarterSetPlay()
+        if setplay.is_kicker(agent):
+            return self.do_kick(agent)
         else:
-            return BhvStarterSetPlayGoalKick.do_move(agent)
+            return self.do_move(agent)
 
-    def do_kick(agent: IAgent):
+    def do_kick(self, agent: IAgent):
         from src.behaviors.starter_setplay.bhv_starter_go_to_placed_ball import BhvStarterGoToPlacedBall
-        
+        go_to_placed_ball = BhvStarterGoToPlacedBall(0.0)
         actions = []
-        actions += BhvStarterSetPlayGoalKick.do_second_kick(agent)
+        actions += self.do_second_kick(agent)
         
-        actions += BhvStarterGoToPlacedBall(0.0).execute(agent)
+        actions += go_to_placed_ball.execute(agent)
 
-        wait = BhvStarterSetPlayGoalKick.do_kick_wait(agent)
+        wait = self.do_kick_wait(agent)
         if wait != []:
             actions += wait
             return actions
         
-        actions += BhvStarterSetPlayGoalKick.do_pass(agent)
+        actions += self.do_pass(agent)
         
-        actions += BhvStarterSetPlayGoalKick.do_kick_to_far_side(agent)
+        actions += self.do_kick_to_far_side(agent)
         
         wm = agent.wm
         real_set_play_count = wm.cycle - agent.wm.last_set_play_start_time
         if real_set_play_count <= agent.server_params.drop_ball_time - 10:
             actions.append(PlayerAction(body_turn_to_ball=Body_TurnToBall(cycle=1)))
             return actions
-        actions.append(BhvStarterClearBall.execute(agent))
+        clear_ball = BhvStarterClearBall()
+        actions.append(clear_ball.execute(agent))
         return actions
 
-    def do_second_kick(agent:IAgent):
+    def do_second_kick(self, agent:IAgent):
         wm = agent.wm
         actions = []
         ball_position = Vector2D(wm.ball.position.x, wm.ball.position.y)
@@ -58,10 +60,11 @@ class BhvStarterSetPlayGoalKick:
             return []
         
         if wm.self.is_kickable:
-            actions += BhvStarterSetPlayGoalKick.do_pass(agent)
-            actions += BhvStarterClearBall.execute(agent)
+            actions += self.do_pass(agent)
+            clear_ball = BhvStarterClearBall()
+            actions += [clear_ball.execute(agent)]
         
-        actions += BhvStarterSetPlayGoalKick.do_intercept(agent)
+        actions += self.do_intercept(agent)
         
         ball_final = Tools.BallInertiaFinalPoint(ball_position, ball_velocity, agent.server_params.ball_decay)
         
@@ -71,15 +74,16 @@ class BhvStarterSetPlayGoalKick:
         
         return actions
 
-    def do_kick_wait(agent:IAgent):
+    def do_kick_wait(self, agent:IAgent):
+        from src.behaviors.starter_setplay.bhv_starter_setplay import BhvStarterSetPlay
+        setplay = BhvStarterSetPlay()
         wm = agent.wm
         actions = []
         real_set_play_count = wm.cycle - wm.last_set_play_start_time
 
         if real_set_play_count >= agent.server_params.drop_ball_time - 10:
             return []
-        from src.behaviors.starter_setplay.bhv_starter_setplay import BhvStarterSetPlay
-        if BhvStarterSetPlay.is_delaying_tactics_situation(agent):
+        if setplay.is_delaying_tactics_situation(agent):
             actions.append(PlayerAction(body_turn_to_ball=Body_TurnToBall(cycle=1)))
             return actions
         
@@ -104,10 +108,11 @@ class BhvStarterSetPlayGoalKick:
             
         return []
 
-    def do_pass(agent:IAgent):
-        return [BhvStarterPass.execute(agent)]
+    def do_pass(self, agent:IAgent):
+        passer = BhvStarterPass()
+        return [passer.execute(agent)]
 
-    def do_intercept(agent:IAgent):
+    def do_intercept(self, agent:IAgent):
         wm = agent.wm
         actions = []
         
@@ -130,13 +135,14 @@ class BhvStarterSetPlayGoalKick:
         
         return actions
 
-    def do_move(agent:"SamplePlayerAgent"):
-        actions = []
-        actions += BhvStarterSetPlayGoalKick.do_intercept(agent)
+    def do_move(self, agent:"SamplePlayerAgent"):
         from src.behaviors.starter_setplay.bhv_starter_setplay import BhvStarterSetPlay
+        setplay = BhvStarterSetPlay()
+        actions = []
+        actions += self.do_intercept(agent)
         wm = agent.wm
         ball_position = Vector2D(wm.ball.position.x, wm.ball.position.y)
-        dash_power = BhvStarterSetPlay.get_set_play_dash_power(agent)
+        dash_power = setplay.get_set_play_dash_power(agent)
         dist_thr = max(wm.ball.dist_from_self * 0.07, 1.0)
 
         target_rpc = Convertor.convert_vector2d_to_rpc_vector2d(agent.strategy.get_position(wm.self.uniform_number, agent))
@@ -174,7 +180,7 @@ class BhvStarterSetPlayGoalKick:
 
         return actions
 
-    def do_kick_to_far_side(agent:IAgent):
+    def do_kick_to_far_side(self, agent:IAgent):
         wm = agent.wm
         actions = []
         target_point = Vector2D(agent.server_params.our_penalty_area_line_x - 5.0, agent.server_params.penalty_area_half_width)

--- a/src/behaviors/starter_setplay/bhv_starter_setplay_indirect_freekick.py
+++ b/src/behaviors/starter_setplay/bhv_starter_setplay_indirect_freekick.py
@@ -57,13 +57,13 @@ class BhvStarterSetPlayIndirectFreeKick:
         actions += BhvStarterPass.execute(agent)
         # wait(2)
         if wm.set_play_count <= 3:
-            actions.append(PlayerAction(body_turn_to_point=Body_TurnToPoint(target_point=RpcVector2D(50, 0), cycle=2)))
+            actions.append(PlayerAction(body_turn_to_point=Body_TurnToPoint(target_point=RpcVector2D(x=50, y=0), cycle=2)))
 
         # no teammate
         if not Tools.TeammatesFromBall(agent) or Tools.TeammatesFromBall()[0].dist_from_self > 35.0 or Tools.TeammatesFromBall()[0].position.x < -30.0:
             real_set_play_count = int(wm.cycle - wm.last_set_play_start_time)
             if real_set_play_count <= agent.server_params.drop_ball_time - 3:
-                actions.append(PlayerAction(body_turn_to_point=Body_TurnToPoint(target_point=RpcVector2D(50, 0), cycle=2)))
+                actions.append(PlayerAction(body_turn_to_point=Body_TurnToPoint(target_point=RpcVector2D(x=50, y=0), cycle=2)))
 
 
             target_point = Vector2D(agent.server_params.pitch_half_length,

--- a/src/behaviors/starter_setplay/bhv_starter_setplay_kickin.py
+++ b/src/behaviors/starter_setplay/bhv_starter_setplay_kickin.py
@@ -103,11 +103,11 @@ class BhvStarterSetPlayKickIn:
             return []
         from src.behaviors.starter_setplay.bhv_starter_setplay import BhvStarterSetPlay
         if BhvStarterSetPlay.is_delaying_tactics_situation(agent):
-            actions.append(PlayerAction(body_turn_to_point=Body_TurnToPoint(target_point=RpcVector2D(0, 0), cycle=2)))
+            actions.append(PlayerAction(body_turn_to_point=Body_TurnToPoint(target_point=RpcVector2D(x=0, y=0), cycle=2)))
             return actions
 
         if not Tools.TeammatesFromBall(agent):
-            actions.append(PlayerAction(body_turn_to_point=Body_TurnToPoint(target_point=RpcVector2D(0, 0), cycle=2)))
+            actions.append(PlayerAction(body_turn_to_point=Body_TurnToPoint(target_point=RpcVector2D(x=0, y=0), cycle=2)))
             return actions
 
         if wm.set_play_count <= 3:

--- a/src/behaviors/starter_setplay/bhv_starter_setplay_kickin.py
+++ b/src/behaviors/starter_setplay/bhv_starter_setplay_kickin.py
@@ -16,28 +16,30 @@ if TYPE_CHECKING:
     from src.sample_player_agent import SamplePlayerAgent
 class BhvStarterSetPlayKickIn:
 
-    def __init__():
+    def __init__(self):
         pass
-    def execute(agent: IAgent) -> bool:
+    def execute(self, agent: IAgent) -> bool:
         from src.behaviors.starter_setplay.bhv_starter_setplay import BhvStarterSetPlay
+        setplay = BhvStarterSetPlay()
 
-        if BhvStarterSetPlay.is_kicker(agent):
-            return BhvStarterSetPlayKickIn.do_kick(agent)
+        if setplay.is_kicker(agent):
+            return self.do_kick(agent)
         else:
-            return BhvStarterSetPlayKickIn.do_move(agent)
+            return self.do_move(agent)
 
         return []
 
-    def do_kick(agent: IAgent):
+    def do_kick(self, agent: IAgent):
         from src.behaviors.starter_setplay.bhv_starter_go_to_placed_ball import BhvStarterGoToPlacedBall
         wm = agent.wm
         actions = []
         # Go to the kick position
         ball_place_angle = -90.0 if wm.ball.position.y > 0.0 else 90.0
-        actions += BhvStarterGoToPlacedBall(ball_place_angle).execute(agent)
+        go_to_placed_ball = BhvStarterGoToPlacedBall(ball_place_angle)
+        actions += go_to_placed_ball.execute(agent)
 
         # Wait
-        wait = BhvStarterSetPlayKickIn.do_kick_wait(agent)
+        wait = self.do_kick_wait(agent)
         if wait != []:
             actions += wait
             return actions
@@ -46,7 +48,8 @@ class BhvStarterSetPlayKickIn:
         max_ball_speed = wm.self.kick_rate * agent.server_params.max_power
 
         # Pass
-        actions.append(BhvStarterPass.execute(agent))
+        passer = BhvStarterPass()
+        actions.append(passer.execute(agent))
 
         # Kick to the nearest teammate
         ball_position = Vector2D(wm.ball.position.x, wm.ball.position.y)
@@ -94,15 +97,16 @@ class BhvStarterSetPlayKickIn:
         return actions
     
 
-    def do_kick_wait(agent: IAgent) -> bool:
+    def do_kick_wait(self, agent: IAgent):
+        from src.behaviors.starter_setplay.bhv_starter_setplay import BhvStarterSetPlay
+        setplay = BhvStarterSetPlay()
         wm = agent.wm
 
         real_set_play_count = wm.cycle - wm.last_set_play_start_time
         actions = []
         if real_set_play_count >= agent.server_params.drop_ball_time - 5:
             return []
-        from src.behaviors.starter_setplay.bhv_starter_setplay import BhvStarterSetPlay
-        if BhvStarterSetPlay.is_delaying_tactics_situation(agent):
+        if setplay.is_delaying_tactics_situation(agent):
             actions.append(PlayerAction(body_turn_to_point=Body_TurnToPoint(target_point=RpcVector2D(x=0, y=0), cycle=2)))
             return actions
 
@@ -123,7 +127,9 @@ class BhvStarterSetPlayKickIn:
 
         return actions
 
-    def do_move(agent: "SamplePlayerAgent"):
+    def do_move(self, agent: "SamplePlayerAgent"):
+        from src.behaviors.starter_setplay.bhv_starter_setplay import BhvStarterSetPlay
+        setplay = BhvStarterSetPlay()
         wm = agent.wm
         actions = []
         ball_position = Vector2D(wm.ball.position.x, wm.ball.position.y)
@@ -150,8 +156,7 @@ class BhvStarterSetPlayKickIn:
                 target_point.set_x(min(max(-agent.server_params.pitch_half_length, target_point.x()), agent.server_params.pitch_half_length))
                 target_point.set_y (min(max(-agent.server_params.pitch_half_width, target_point.y()), agent.server_params.pitch_half_width))
                 avoid_opponent = True
-        from src.behaviors.starter_setplay.bhv_starter_setplay import BhvStarterSetPlay
-        dash_power = BhvStarterSetPlay.get_set_play_dash_power(agent)
+        dash_power = setplay.get_set_play_dash_power(agent)
         dist_thr = wm.ball.dist_from_self * 0.07
         dist_thr = max(dist_thr, 1.0)
         tm = Tools.TeammatesFromBall(agent)

--- a/src/behaviors/starter_setplay/bhv_starter_their_goal_kick_move.py
+++ b/src/behaviors/starter_setplay/bhv_starter_their_goal_kick_move.py
@@ -93,7 +93,7 @@ class BhvStarterTheirGoalKickMove:
                 target_point.set_y(target_point.y() * -1)
 
         dist_thr = max(wm.ball.dist_from_self * 0.07, 1.0)
-        actions.append(PlayerAction(body_go_to_point=Body_GoToPoint(Convertor.convert_vector2d_to_rpc_vector2d(target_point), distance_threshold=dist_thr, max_dash_power=dash_power)))
+        actions.append(PlayerAction(body_go_to_point=Body_GoToPoint(target_point=Convertor.convert_vector2d_to_rpc_vector2d(target_point), distance_threshold=dist_thr, max_dash_power=dash_power)))
         actions.append(PlayerAction(body_turn_to_ball=Body_TurnToBall(cycle=0)))
         
         return actions

--- a/src/behaviors/starter_setplay/bhv_starter_their_goal_kick_move.py
+++ b/src/behaviors/starter_setplay/bhv_starter_their_goal_kick_move.py
@@ -18,7 +18,7 @@ class BhvStarterTheirGoalKickMove:
     def __init__(self):
         pass
     
-    def execute(agent: IAgent) -> bool:
+    def execute(self, agent: IAgent) -> bool:
         expand_their_penalty = Rect2D(
             Vector2D(agent.server_params.their_penalty_area_line_x - 0.75,
                       -agent.server_params.penalty_area_half_width - 0.75),
@@ -28,7 +28,7 @@ class BhvStarterTheirGoalKickMove:
 
         wm = agent.wm
         actions = []
-        actions += BhvStarterTheirGoalKickMove.do_chase_ball(agent)
+        actions += self.do_chase_ball(agent)
 
         
         self_position = Vector2D(wm.self.position.x, wm.self.position.y)
@@ -38,11 +38,11 @@ class BhvStarterTheirGoalKickMove:
         intersection = intersection_list[0]
         if ball_velocity.r()  > 0.2:
             if not expand_their_penalty.contains(ball_position) or len(intersection_list)  != 1: #TODO Check
-                return BhvStarterTheirGoalKickMove.do_normal(agent)
+                return self.do_normal(agent)
         else:
             if (wm.ball.position.x > agent.server_params.their_penalty_area_line_x + 7.0 and
                 abs(wm.ball.position.y) < (agent.server_params.goal_width/2.0) + 2.0):
-                return BhvStarterTheirGoalKickMove.do_normal(agent)
+                return self.do_normal(agent)
 
             intersection.set_x(agent.server_params.their_penalty_area_line_x - 0.76)
             intersection.set_y(wm.ball.position.y)
@@ -52,7 +52,7 @@ class BhvStarterTheirGoalKickMove:
         nearest_tm_pos = Vector2D(nearest_tm.position.x, nearest_tm.position.y)
         min_dist = nearest_tm_pos.dist(intersection)
         if min_dist < self_position.dist(intersection):
-            return BhvStarterTheirGoalKickMove.do_normal(agent)
+            return self.do_normal(agent)
         dash_power = wm.self.get_safety_dash_power #TODO
 
         if intersection.x() < agent.server_params.their_penalty_area_line_x and wm.self.position.x > agent.server_params.their_penalty_area_line_x - 0.5:
@@ -72,11 +72,12 @@ class BhvStarterTheirGoalKickMove:
         
         return actions
 
-    def do_normal(agent: "SamplePlayerAgent"):
+    def do_normal(self, agent: "SamplePlayerAgent"):
         wm = agent.wm
         actions = []
         from src.behaviors.starter_setplay.bhv_starter_setplay import BhvStarterSetPlay
-        dash_power = BhvStarterSetPlay.get_set_play_dash_power(agent)
+        setplay = BhvStarterSetPlay()
+        dash_power = setplay.get_set_play_dash_power(agent)
         targ = Convertor.convert_vector2d_to_rpc_vector2d(agent.strategy.get_position(wm.self.uniform_number, agent))
         target_point = Vector2D(targ.x, targ.y)
 
@@ -97,7 +98,7 @@ class BhvStarterTheirGoalKickMove:
         
         return actions
 
-    def do_chase_ball(agent: IAgent) -> bool:
+    def do_chase_ball(self, agent: IAgent) -> bool:
         wm = agent.wm
         actions = []
         ball_position = Vector2D(wm.ball.position.x, wm.ball.position.y)

--- a/src/behaviors/starter_setplay/bhv_starter_their_goal_kick_move.py
+++ b/src/behaviors/starter_setplay/bhv_starter_their_goal_kick_move.py
@@ -67,7 +67,7 @@ class BhvStarterTheirGoalKickMove:
 
         dist_thr = max(wm.ball.dist_from_self * 0.07, 1.0)
         
-        actions.append(PlayerAction(body_go_to_point=Body_GoToPoint(Convertor.convert_vector2d_to_rpc_vector2d(intersection), distance_threshold=dist_thr, max_dash_power=dash_power)))
+        actions.append(PlayerAction(body_go_to_point=Body_GoToPoint(target_point=Convertor.convert_vector2d_to_rpc_vector2d(intersection), distance_threshold=dist_thr, max_dash_power=dash_power)))
         actions.append(PlayerAction(body_turn_to_ball=Body_TurnToBall(cycle=0)))
         
         return actions


### PR DESCRIPTION
This pull request includes several changes to the behavior classes in the `src/behaviors` directory to improve the consistency and functionality of the agent's actions. The most important changes involve modifying method signatures to include `self`, fixing commented-out code, and ensuring the correct instances are used when calling methods.

### Consistency and Functionality Improvements:

* [`src/behaviors/bhv_starter_clearball.py`](diffhunk://#diff-dd4193ce2cc6a7ce8485cd20b434506733c4099d60bf48a29fe99a42345f3489L15-R15): Changed the `execute` method to include `self` as a parameter.
* [`src/behaviors/bhv_starter_dribble.py`](diffhunk://#diff-cbc0f2e3b07b5304a9be2088c0b6bb76eb548301e437c6f1a574aa26e1bd582cL14-R14): Changed the `execute` method to include `self` as a parameter.
* [`src/behaviors/bhv_starter_pass.py`](diffhunk://#diff-e57b3f3cdaf7d708e06e7f7c7f8ea37b9e00fef82b95b05e3b0fd163c4921ccfL14-R14): Changed the `execute` method to include `self` as a parameter.
* [`src/behaviors/bhv_starter_shoot.py`](diffhunk://#diff-0633fcde1ceb1690c1247f9a63f558c94504fc628774ce0b2de6c4f4b5f801d0L12-R12): Changed the `execute` method to include `self` as a parameter.
* [`src/behaviors/starter_setplay/bhv_starter_go_to_placed_ball.py`](diffhunk://#diff-8bb8be93f8b5827ed83e5b005beb67056fff2a725cd7ed426609bbe36b083c3bL11-R16): Removed unnecessary `pass` statement and instantiated `BhvStarterSetPlay` within the `execute` method. [[1]](diffhunk://#diff-8bb8be93f8b5827ed83e5b005beb67056fff2a725cd7ed426609bbe36b083c3bL11-R16) [[2]](diffhunk://#diff-8bb8be93f8b5827ed83e5b005beb67056fff2a725cd7ed426609bbe36b083c3bL34-R35)

### Refactoring and Bug Fixes:

* [`src/behaviors/bhv_starter_kick_planner.py`](diffhunk://#diff-4158415b44a7e61b7b0f6f4b17a33d12280c283bef4d608d3f3a0c263a35b8f8L14-R36): Fixed commented-out code and ensured the correct instances of behaviors are used when calling the `execute` method.
* [`src/behaviors/bhv_starter_penalty.py`](diffhunk://#diff-b8680b0b34b81ff9062342d4e8cc6384f7e28beb70b23aa0c6a864fd1bdbfb3fL95-R96): Adjusted method calls to use the correct instances and parameters, ensuring proper execution flow. [[1]](diffhunk://#diff-b8680b0b34b81ff9062342d4e8cc6384f7e28beb70b23aa0c6a864fd1bdbfb3fL95-R96) [[2]](diffhunk://#diff-b8680b0b34b81ff9062342d4e8cc6384f7e28beb70b23aa0c6a864fd1bdbfb3fL152-R153) [[3]](diffhunk://#diff-b8680b0b34b81ff9062342d4e8cc6384f7e28beb70b23aa0c6a864fd1bdbfb3fL327-R329) [[4]](diffhunk://#diff-b8680b0b34b81ff9062342d4e8cc6384f7e28beb70b23aa0c6a864fd1bdbfb3fL341-R343) [[5]](diffhunk://#diff-b8680b0b34b81ff9062342d4e8cc6384f7e28beb70b23aa0c6a864fd1bdbfb3fL355-R358)

### Code Cleanup and Enhancements:

* [`src/behaviors/starter_setplay/bhv_starter_prepare_setplay_kick.py`](diffhunk://#diff-3d552d125f11594347aa6e6c29b730e73761982e874a8c4da034bf2a4a466126L12-R17): Refactored the `execute` method to create an instance of `BhvStarterGoToPlacedBall` and use it appropriately.
* [`src/behaviors/starter_setplay/bhv_starter_setplay.py`](diffhunk://#diff-f931ac298b0b0ec329bd69338f2a379f3d5eb297717bd339c6666c3d06f9615cL6-R18): Updated imports, refactored methods to include `self`, and ensured the correct instances are used for method calls and decision-making processes. [[1]](diffhunk://#diff-f931ac298b0b0ec329bd69338f2a379f3d5eb297717bd339c6666c3d06f9615cL6-R18) [[2]](diffhunk://#diff-f931ac298b0b0ec329bd69338f2a379f3d5eb297717bd339c6666c3d06f9615cL26-R85) [[3]](diffhunk://#diff-f931ac298b0b0ec329bd69338f2a379f3d5eb297717bd339c6666c3d06f9615cL94-R102) [[4]](diffhunk://#diff-f931ac298b0b0ec329bd69338f2a379f3d5eb297717bd339c6666c3d06f9615cL111-R125) [[5]](diffhunk://#diff-f931ac298b0b0ec329bd69338f2a379f3d5eb297717bd339c6666c3d06f9615cL135-R143) [[6]](diffhunk://#diff-f931ac298b0b0ec329bd69338f2a379f3d5eb297717bd339c6666c3d06f9615cL146-R160) [[7]](diffhunk://#diff-f931ac298b0b0ec329bd69338f2a379f3d5eb297717bd339c6666c3d06f9615cL163-R171) [[8]](diffhunk://#diff-f931ac298b0b0ec329bd69338f2a379f3d5eb297717bd339c6666c3d06f9615cL223-R231) [[9]](diffhunk://#diff-f931ac298b0b0ec329bd69338f2a379f3d5eb297717bd339c6666c3d06f9615cL241-R254) [[10]](diffhunk://#diff-f931ac298b0b0ec329bd69338f2a379f3d5eb297717bd339c6666c3d06f9615cL258-R266)