### PR TITLE
refactor: replace pkg_resources with importlib + packaging

### DIFF
--- a/check_requirements.py
+++ b/check_requirements.py
@@ -1,20 +1,35 @@
-
-import pkg_resources
 import sys
+from importlib.metadata import version, PackageNotFoundError
+from packaging.requirements import Requirement
+from packaging.version import Version
 
 def check_requirements(requirements_file='requirements.txt'):
     with open(requirements_file, 'r') as file:
         requirements = file.readlines()
 
-    for requirement in requirements:
-        requirement = requirement.strip()
-        try:
-            pkg_resources.require(requirement)
-        except pkg_resources.VersionConflict as e:
-            print(f"WARNING: {str(e)}")
-        except pkg_resources.DistributionNotFound as e:
-            print(f"ERROR: {str(e)}")
-            sys.exit(1)
+        for requirement_line in requirements:
+            requirement_line = requirement_line.strip()
+            if not requirement_line or requirement_line.startswith('#'):
+                continue
+
+            try:
+                req = Requirement(requirement_line)
+                try:
+                    # Get installed version
+                    installed_version = version(req.name)
+                    installed = Version(installed_version)
+
+                    # Check if versions matches
+                    if req.specifier and not req.specifier.contains(installed):
+                        print(f"WARNING: Version conflict for {req.name}. "
+                          f"Required: {req.specifier}, installed: {installed_version}")
+                    
+                except PackageNotFoundError:
+                    print(f"ERROR: Package {req.name} not found")
+                    sys.exit(1)
+                
+            except Exception as e:
+                print(f"WARNING: Could not parse requirement '{requirement_line}': {str(e)}")
 
 if __name__ == "__main__":
     check_requirements()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,12 @@
 grpcio==1.65.4
 grpcio-tools==1.65.4
-scipy==1.14.1
-pyrusgeom==0.1.2
 Nuitka==2.5
+numpy==2.2.4
+ordered-set==4.1.0
+packaging==24.2
+protobuf==5.29.4
 psutil==5.8.0
+pyrusgeom==0.1.2
+scipy==1.14.1
+setuptools==78.1.0
+zstandard==0.23.0


### PR DESCRIPTION
This pull request addresses the deprecation of `pkg_resources` by refactoring `check_requirements.py` to use `importlib.metadata` and `packaging` for checking installed packages and their versions.

### Related Issue

No GitHub issue was formally opened, but this change resolves the implicit need to modernize dependency checks in line with current Python best practices.

### What this PR does

- Replaces `pkg_resources.require()` with:
  - `importlib.metadata.version()` for retrieving installed versions
  - `packaging.requirements.Requirement` for parsing requirements
  - `packaging.version.Version` for comparing installed versions
- Improves handling of:
  - Missing packages (`PackageNotFoundError`)
  - Version mismatches with warning messages
  - Skipping empty lines and comments in `requirements.txt`
- Ensures the script exits only when a required package is missing

### How I tested it

- Ran the script locally with a sample `requirements.txt` containing:
  - Installed packages with valid versions
  - Non-installed packages
  - Version mismatches
  - Commented and empty lines
- Verified that:
  - Missing packages cause the script to exit with an error
  - Version mismatches produce warnings
  - Valid packages pass silently

### Additional notes

- This change assumes that the `packaging` module is available in the environment. If not, it should be added to the project's requirements.
- Tested on Python 3.11 and 3.12
